### PR TITLE
change crackmapexec to netexec since crackmapexec is deprecated

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,31 +11,31 @@ password = sys.argv[3]
 
 print('Trying credentials against smb...')
 print('======================================================================================================')
-os.system(f'crackmapexec smb {host} -u {username} -p {password}')
+os.system(f'netexec smb {host} -u {username} -p {password}')
 print('======================================================================================================')
 
 print('Trying credentials against ldap')
 print('======================================================================================================')
-os.system(f'crackmapexec ftp {host} -u {username} -p {password}')
+os.system(f'netexec ftp {host} -u {username} -p {password}')
 print('======================================================================================================')
 
 print('Trying credentials against ssh')
 print('======================================================================================================')
-os.system(f'crackmapexec ssh {host} -u {username} -p {password}')
+os.system(f'netexec ssh {host} -u {username} -p {password}')
 print('======================================================================================================')
 
 print('Trying credentials against winrm')
 print('======================================================================================================')
-os.system(f'crackmapexec winrm {host} -u {username} -p {password}')
+os.system(f'netexec winrm {host} -u {username} -p {password}')
 print('======================================================================================================')
 
 print('Trying credentials against rdp')
 print('======================================================================================================')
-os.system(f'crackmapexec rdp {host} -u {username} -p {password}')
+os.system(f'netexec rdp {host} -u {username} -p {password}')
 print('======================================================================================================')
 
 print('Trying credentials against mssql')
 print('======================================================================================================')
-os.system(f'crackmapexec mssql {host} -u {username} -p {password}')
+os.system(f'netexec mssql {host} -u {username} -p {password}')
 print('======================================================================================================')
 print('End.')


### PR DESCRIPTION
crackmapexec has been archived by the owner on Dec 6, 2023. Netexec is a drop-in replacement for it.